### PR TITLE
Add code coverage option for cmake builds

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,18 +6,31 @@ jobs:
     name: Ubuntu GCC build and unit tests
     runs-on: ubuntu-18.04
     steps:
-    - name: Install Boost
-      run:  sudo apt install libboost-all-dev
+    - name: Install boost and lcov
+      run:  sudo apt install libboost-all-dev lcov
     - name: Clone repo
       uses: actions/checkout@v1
       with:
         submodules: true
     - name: Configure
-      run:  cmake .
+      run:  cmake -DCODE_COVERAGE=ON -DCMAKE_BUILD_TYPE=Debug .
     - name: Build
-      run:  make -j 8
+      run:  make -j $(nproc)
+      env:
+        CLICOLOR_FORCE: 1
     - name: Unit tests
-      run:  env CTEST_OUTPUT_ON_FAILURE=1 make test
+      run:  make test
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1
+    - name: Coverage
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        lcov --capture --directory . --output-file coverage.info
+        lcov --remove coverage.info "/usr/*" "$(pwd)/3party/*" "*/googletest-src/*" --output-file coverage.info # filter external
+        lcov --list coverage.info # debug info
+        # Uploading report to CodeCov
+        curl -s https://codecov.io/bash | bash -s -- -f coverage.info || echo "Codecov did not collect coverage reports"
 
   build_clang:
     name: MacOS Clang build and unit tests
@@ -32,6 +45,10 @@ jobs:
     - name: Configure
       run:  cmake .
     - name: Build
-      run:  make -j 8
+      run:  make -j $(sysctl -n hw.ncpu)
+      env:
+        CLICOLOR_FORCE: 1
     - name: Unit tests
-      run:  env CTEST_OUTPUT_ON_FAILURE=1 make test
+      run:  make test
+      env:
+        CTEST_OUTPUT_ON_FAILURE: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,23 @@ if (NOT SKIP_TESTS)
   configure_gtest()
 endif()
 
+# Code Coverage Configuration
+add_library(coverage_config INTERFACE)
+
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
+if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  # Add required flags (GCC & LLVM/Clang)
+  target_compile_options(coverage_config INTERFACE
+    -O0        # no optimization
+    -g         # generate debug info
+    --coverage # sets all required flags
+)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(coverage_config INTERFACE --coverage)
+  else()
+    target_link_libraries(coverage_config INTERFACE --coverage)
+  endif()
+endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LINUX_DETECTED TRUE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Bunch of code for geoservices
 
-![Actions Status](http://aliyunfc.tarocch1.com/github-actions-badge/mapsme/geocore/?style=flat-square)
+![Actions Status](https://github.com/LaGrunge/geocore/workflows/.github/workflows/ccpp.yml/badge.svg)
+
+
+[![codecov][codecov-badge]][codecov-link]
+
+
+
 
 ## Submodules
 
@@ -14,3 +20,6 @@ run `git submodule update --init --recursive`.
 This source code is Copyright (C) 2015 My.com B.V. (Mail.Ru Group), published under Apache Public License 2.0,
 except third-party libraries. See [NOTICE](https://github.com/mapsme/geocore/blob/master/NOTICE)
 and [data/copyright.html](http://htmlpreview.github.io/?https://github.com/mapsme/geocore/blob/master/data/copyright.html) files for more information.
+
+[codecov-badge]:   https://codecov.io/gh/LaGrunge/geocore/branch/master/graph/badge.svg
+[codecov-link]:    https://codecov.io/gh/LaGrunge/geocore

--- a/cmake/GeoCoreHelpers.cmake
+++ b/cmake/GeoCoreHelpers.cmake
@@ -43,7 +43,7 @@ endfunction()
 
 function(geocore_add_library library)
   add_library(${library} ${ARGN})
-  add_dependencies(${library} BuildVersion)
+  target_link_libraries(${library} coverage_config)
 endfunction()
 
 function(geocore_add_test executable)


### PR DESCRIPTION
Use it in pipeline and send report to codecov.io
Uses CODECOV token, lcov ang gcc --coverage