### PR TITLE
Future clang icu warn supress

### DIFF
--- a/3party/icu/CMakeLists.txt
+++ b/3party/icu/CMakeLists.txt
@@ -10,7 +10,7 @@ add_definitions(
   -DU_ENABLE_DYLOAD=0
 )
 
-add_clang_compile_options("-Wno-deprecated-declarations" "-Wno-enum-compare-switch")
+add_clang_compile_options("-Wno-deprecated-declarations" "-Wno-enum-compare-switch" "-Wno-enum-compare")
 add_gcc_compile_options("-Wno-deprecated-declarations" "-Wno-stringop-overflow")
 
 set(CMAKE_PREFIX_PATH ./)


### PR DESCRIPTION
При сборке icu у b2c валятся ворнинги и они засупрессили их себе так.
У нас не валятся, но могут при обновлении clang