### PR TITLE
[geocoder] Improve rank for Moscow case and full address matching

### DIFF
--- a/geocoder/geocoder.cpp
+++ b/geocoder/geocoder.cpp
@@ -45,7 +45,7 @@ size_t const kMaxResults = 100;
 // possible with respect to the IsParentTo relation on entries.
 // In other words, non-scaled post-probabilities are
 //   log(Prob(Country|token)) ~ 10
-//   log(Prob(Region|token)) ~ 5
+//   log(Prob(Region|token)) ~ 4
 //   etc.
 // The greater their sum, the more likely it is that we guessed the
 // token types right.
@@ -62,12 +62,12 @@ double GetWeight(Type t)
   switch (t)
   {
   case Type::Country: return 10.0;
-  case Type::Region: return 5.0;
+  case Type::Region: return 4.0;
   case Type::Subregion: return 4.0;
-  case Type::Locality: return 3.0;
-  case Type::Suburb: return 3.0;
-  case Type::Sublocality: return 2.0;
-  case Type::Street: return 1.0;
+  case Type::Locality: return 5.0;
+  case Type::Suburb: return 1.0;
+  case Type::Sublocality: return 1.0;
+  case Type::Street: return 2.0;
   case Type::Building: return 0.1;
   case Type::Count: return 0.0;
   }

--- a/geocoder/geocoder_tests/geocoder_tests.cpp
+++ b/geocoder/geocoder_tests/geocoder_tests.cpp
@@ -96,7 +96,7 @@ UNIT_TEST(Geocoder_EnglishNames)
   ScopedFile const regionsJsonFile("regions.jsonl", kData);
   geocoder.LoadFromJsonl(regionsJsonFile.GetFullPath());
 
-  TestGeocoder(geocoder, "Moscow, New Arbat", {{Id{0x11}, 1.0}, {Id{0x10}, 0.6}});
+  TestGeocoder(geocoder, "Moscow, New Arbat", {{Id{0x11}, 1.0}, {Id{0x10}, 0.5555}});
 }
 
 UNIT_TEST(Geocoder_OnlyBuildings)
@@ -126,8 +126,8 @@ UNIT_TEST(Geocoder_OnlyBuildings)
   base::GeoObjectId const building10(0x32);
 
   TestGeocoder(geocoder, "some locality", {{localityId, 1.0}});
-  TestGeocoder(geocoder, "some locality good", {{goodStreetId, 1.0}, {localityId, 0.857143}});
-  TestGeocoder(geocoder, "some locality bad", {{badStreetId, 1.0}, {localityId, 0.857143}});
+  TestGeocoder(geocoder, "some locality good", {{goodStreetId, 1.0}, {localityId, 0.833333}});
+  TestGeocoder(geocoder, "some locality bad", {{badStreetId, 1.0}, {localityId, 0.833333}});
 
   TestGeocoder(geocoder, "some locality good 5", {{building5, 1.0}});
   TestGeocoder(geocoder, "some locality bad 10", {{building10, 1.0}});
@@ -142,7 +142,7 @@ UNIT_TEST(Geocoder_OnlyBuildings)
   base::GeoObjectId const numberedStreet(0x41);
   base::GeoObjectId const houseOnANonNumberedStreet(0x42);
   TestGeocoder(geocoder, "some locality maybenumbered 3",
-               {{numberedStreet, 1.0}, {houseOnANonNumberedStreet, 0.8875}});
+               {{numberedStreet, 1.0}, {houseOnANonNumberedStreet, 0.864286}});
 }
 
 UNIT_TEST(Geocoder_MismatchedLocality)
@@ -187,10 +187,10 @@ UNIT_TEST(Geocoder_MoscowLocalityRank)
   ScopedFile const regionsJsonFile("regions.jsonl", kData);
   geocoder.LoadFromJsonl(regionsJsonFile.GetFullPath());
 
-  TestGeocoder(geocoder, "Москва", {{Id{0x10}, 1.0}, {Id{0x11}, 0.61}, {Id{0x21}, 0.6}});
-  TestGeocoder(geocoder, "Москва, Ленинский проспект", {{Id{0x12}, 1.0}, {Id{0x22}, 0.70922},
-                                                        {Id{0x10}, 0.70922}, {Id{0x11}, 0.432624},
-                                                        {Id{0x21}, 0.425532}});
+  TestGeocoder(geocoder, "Москва", {{Id{0x11}, 1.0}, {Id{0x21}, 0.990099}, {Id{0x10}, 0.792079}});
+  TestGeocoder(geocoder, "Москва, Ленинский проспект", {{Id{0x12}, 1.0}, {Id{0x22}, 0.994475},
+                                                        {Id{0x11}, 0.558011}, {Id{0x21}, 0.552486},
+                                                        {Id{0x10}, 0.441989}});
 }
 
 // Geocoder_StreetWithNumber* ----------------------------------------------------------------------
@@ -333,7 +333,7 @@ UNIT_TEST(Geocoder_LocalityAndStreetBuildingsRank)
   ScopedFile const regionsJsonFile("regions.jsonl", kData);
   geocoder.LoadFromJsonl(regionsJsonFile.GetFullPath());
 
-  TestGeocoder(geocoder, "Zelenograd, Krymskaya 2", {{Id{0x32}, 1.0}, {Id{0x22}, 0.7560}});
+  TestGeocoder(geocoder, "Zelenograd, Krymskaya 2", {{Id{0x32}, 1.0}, {Id{0x22}, 0.71831}});
 }
 
 // Geocoder_Subregion* -----------------------------------------------------------------------------
@@ -351,8 +351,8 @@ UNIT_TEST(Geocoder_SubregionInLocality)
 
   TestGeocoder(geocoder, "Северный административный округ", {{Id{0x12}, 1.0}});
   TestGeocoder(geocoder, "Москва, Северный административный округ",
-               {{Id{0x12}, 1.0}, {Id{0x10}, 0.293255}, {Id{0x11}, 0.178886}});
-  TestGeocoder(geocoder, "Москва", {{Id{0x10}, 1.0}, {Id{0x11}, 0.61}});
+               {{Id{0x12}, 1.0}, {Id{0x11}, 0.314642}, {Id{0x10}, 0.249221}});
+  TestGeocoder(geocoder, "Москва", {{Id{0x11}, 1.0}, {Id{0x10}, 0.792079}});
 }
 
 // Geocoder_NumericalSuburb* ----------------------------------------------------------------------


### PR DESCRIPTION
Улучшения ранжирования для города Москвы (выше ранга региона Москвы).

Оценка качества:
до
```
full_matched                            8072    80.72
full_empty                              598     5.98
```

после
```
full_matched                            8075    80.75
full_empty                              599     5.99
```
