### PR TITLE
[generator] Optimize pre-processing stage: clear osm element

### DIFF
--- a/generator/osm_source.cpp
+++ b/generator/osm_source.cpp
@@ -171,7 +171,7 @@ bool ProcessorOsmElementsFromO5M::TryRead(OsmElement & element)
     }
   };
 
-  element = {};
+  element.Clear();
 
   // Be careful, we could call Nodes(), Members(), Tags() from O5MSource::Entity
   // only once (!). Because these functions read data from file simultaneously with


### PR DESCRIPTION
Измерения для `--preprocess=true` (индексирование node, way, relation):
до (до cttrie)
```
real    144m11.445s
user    95m40.879s
sys     42m33.005s
```
после
```
real    134m28.989s
user    83m59.850s
sys     44m43.325s
```
На ~10 минут быстрее