### PR TITLE
[generator] Optimize preprocessing stage: output buffer large size

### DIFF
--- a/generator/intermediate_data.cpp
+++ b/generator/intermediate_data.cpp
@@ -18,7 +18,7 @@ namespace cache
 {
 namespace
 {
-size_t const kFlushCount = 1024;
+size_t const kFlushCount = 10'000'000;
 double const kValueOrder = 1e7;
 string const kShortExtension = ".short";
 
@@ -321,6 +321,7 @@ bool IndexFileReader::GetValueByKey(Key key, Value & value) const
 IndexFileWriter::IndexFileWriter(string const & name) :
   m_fileWriter(name.c_str())
 {
+  m_elements.reserve(kFlushCount);
 }
 
 void IndexFileWriter::WriteAll()
@@ -356,7 +357,10 @@ OSMElementCacheReader::OSMElementCacheReader(string const & name, bool preload, 
 
 // OSMElementCacheWriter ---------------------------------------------------------------------------
 OSMElementCacheWriter::OSMElementCacheWriter(string const & name, bool preload)
-  : m_fileWriter(name), m_offsets(name + OFFSET_EXT), m_name(name), m_preload(preload)
+  : m_fileWriter(name, FileWriter::OP_WRITE_TRUNCATE, 10 * 1024 * 1024 /* bufferSize */)
+  , m_offsets(name + OFFSET_EXT)
+  , m_name(name)
+  , m_preload(preload)
 {
 }
 

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -3,6 +3,7 @@
 #include "generator/generate_info.hpp"
 #include "generator/intermediate_elements.hpp"
 
+#include "coding/buffered_file_writer.hpp"
 #include "coding/file_reader.hpp"
 #include "coding/file_writer.hpp"
 #include "coding/mmap_reader.hpp"
@@ -189,7 +190,7 @@ public:
   void SaveOffsets();
 
 protected:
-  FileWriter m_fileWriter;
+  BufferedFileWriter m_fileWriter;
   IndexFileWriter m_offsets;
   std::string m_name;
   std::vector<uint8_t> m_data;


### PR DESCRIPTION
Измерения для `--preprocess=true` (индексирование node, way, relation):
до (без других оптимизаций)
```
real    144m11.445s
user    95m40.879s
sys     42m33.005s
```
после (только с этой оптимизацией)
```
real    139m14.280s
user    92m18.819s
sys     41m25.332s
```
Ускорение на ~4 минуты