### PR TITLE
[generator:preprocess] Optimize system call lseek() usage

### DIFF
--- a/generator/intermediate_data.cpp
+++ b/generator/intermediate_data.cpp
@@ -358,6 +358,7 @@ OSMElementCacheReader::OSMElementCacheReader(string const & name, bool preload, 
 // OSMElementCacheWriter ---------------------------------------------------------------------------
 OSMElementCacheWriter::OSMElementCacheWriter(string const & name, bool preload)
   : m_fileWriter(name, FileWriter::OP_WRITE_TRUNCATE, 10 * 1024 * 1024 /* bufferSize */)
+  , m_currOffset{m_fileWriter.Pos()}
   , m_offsets(name + OFFSET_EXT)
   , m_name(name)
   , m_preload(preload)

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -175,7 +175,7 @@ public:
   template <typename Value>
   void Write(Key id, Value const & value)
   {
-    m_offsets.Add(id, m_fileWriter.Pos());
+    m_offsets.Add(id, m_currOffset);
     m_data.clear();
     MemWriter<decltype(m_data)> w(m_data);
 
@@ -185,12 +185,14 @@ public:
     uint32_t sz = static_cast<uint32_t>(m_data.size());
     m_fileWriter.Write(&sz, sizeof(sz));
     m_fileWriter.Write(m_data.data(), sz);
+    m_currOffset += sizeof(sz) + sz;
   }
 
   void SaveOffsets();
 
 protected:
   BufferedFileWriter m_fileWriter;
+  uint64_t m_currOffset{0};
   IndexFileWriter m_offsets;
   std::string m_name;
   std::vector<uint8_t> m_data;


### PR DESCRIPTION
Ускорение `--preprocess` на ~54% (~60 минут):
до
```
real    113m38.327s
user    64m29.775s
sys     43m2.894s
```
после
```
real    52m13.603s
user    39m24.375s
sys     7m9.335s
```