### PR TITLE
[generator:preprocess] Optimize o5m reading: parallel reading

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -154,6 +154,8 @@ set(
   world_map_generator.hpp
 )
 
+find_package(Boost REQUIRED COMPONENTS iostreams)
+
 geocore_add_library(${PROJECT_NAME} ${SRC})
 geocore_link_libraries(${PROJECT_NAME}
   base
@@ -162,6 +164,7 @@ geocore_link_libraries(${PROJECT_NAME}
   platform
   geometry
   jansson
+  ${Boost_LIBRARIES}
 )
 
 geocore_add_test_subdirectory(generator_tests_support)

--- a/generator/generate_info.hpp
+++ b/generator/generate_info.hpp
@@ -39,7 +39,7 @@ struct GenerateInfo
   OsmSourceType m_osmFileType;
   std::string m_osmFileName;
 
-  unsigned int m_threadsCount;
+  unsigned int m_threadsCount{1};
 
   bool m_preloadCache = false;
   bool m_verbose = false;

--- a/generator/towns_dumper.cpp
+++ b/generator/towns_dumper.cpp
@@ -58,7 +58,7 @@ void TownsDumper::FilterTowns()
   LOG(LINFO, ("Preprocessing finished. Have", m_records.size(), "towns."));
 }
 
-void TownsDumper::CheckElement(OsmElement const & em)
+void TownsDumper::CheckElement(OsmElement const & em, bool /* concurrent */)
 {
   if (em.m_type != OsmElement::EntityType::Node)
     return;
@@ -96,7 +96,10 @@ void TownsDumper::CheckElement(OsmElement const & em)
     capital = false;
 
   if (town || capital)
+  {
+    std::lock_guard<std::mutex> lock{m_updateMutex};
     m_records.emplace_back(em.m_lat, em.m_lon, em.m_id, capital, population);
+  }
 }
 
 void TownsDumper::Dump(std::string const & filePath)

--- a/generator/towns_dumper.hpp
+++ b/generator/towns_dumper.hpp
@@ -8,6 +8,7 @@
 
 #include "base/string_utils.hpp"
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -16,7 +17,7 @@ class TownsDumper
 public:
   TownsDumper();
 
-  void CheckElement(OsmElement const & em);
+  void CheckElement(OsmElement const & em, bool concurrent);
 
   void Dump(std::string const & filePath);
 
@@ -43,4 +44,5 @@ private:
   };
 
   std::vector<Town> m_records;
+  std::mutex m_updateMutex;
 };


### PR DESCRIPTION
Ускорение `--preprocess=true` на ~53% (на ~30 минут) на b2b-gen (OpenStack, AMD, 56 тредов)
до
```
real    54m6.213s
user    42m35.481s
sys     5m32.303s
```
после
```
real    25m15.012s
user    742m11.202s
sys     56m14.943s
```