### PR TITLE
[generator:preprocess] Optimize o5m reading: readahead usage

### DIFF
--- a/generator/osm_source.cpp
+++ b/generator/osm_source.cpp
@@ -23,6 +23,8 @@
 #include <boost/iostreams/device/mapped_file.hpp>
 #include <boost/iostreams/stream.hpp>
 
+#include <sys/mman.h>
+
 #include "defines.hpp"
 
 using namespace std;
@@ -251,6 +253,7 @@ void BuildIntermediateDataFromO5M(
   auto sourceMap = boost::iostreams::mapped_file_source{filename};
   if (!sourceMap.is_open())
     MYTHROW(Writer::OpenException, ("Failed to open", filename));
+  ::madvise(const_cast<char*>(sourceMap.data()), sourceMap.size(), MADV_SEQUENTIAL);
 
   constexpr size_t chunkSize = 10'000;
   std::vector<std::thread> threads;


### PR DESCRIPTION
Упреждающее чтение для o5m фала, отображенного в память. Влияет на ускорение, только если файл вытеснился из кэша. Обычно это не происходит, т.к. o5m файл генерируется пред. стадией.