### PR TITLE
[generator:preprocess] Optimize node file write: async write by mmap()

### DIFF
--- a/generator/generator_tests/intermediate_data_test.cpp
+++ b/generator/generator_tests/intermediate_data_test.cpp
@@ -170,7 +170,7 @@ void TestIntermediateDataGeneration(
     auto const & osmFileData = sample.second;
 
     // Skip test for node storage type "mem": 64Gb required.
-    for (auto const & nodeStorageType : {"raw"s, "map"s})
+    for (auto const & nodeStorageType : {"raw"s, "map"s, "mem"s})
     {
       for (auto threadsCount : {1, 2, 4})
       {


### PR DESCRIPTION
Запись nodes.data через отображённый файл, вместо системного write().

Ускорение `--preprocess=true` на ~38% (на ~10 минут) на b2b-gen (OpenStack, AMD, 56 тредов)
До
```
real    25m15.012s
user    742m11.202s
sys     56m14.943s
```
после
```
real    15m41.540s
user    709m57.243s
sys     17m52.473s
```