### PR TITLE
[generator:features] shared intermediate data in memory

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -152,7 +152,7 @@ set(
   world_map_generator.hpp
 )
 
-find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(Boost REQUIRED COMPONENTS iostreams filesystem)
 
 geocore_add_library(${PROJECT_NAME} ${SRC})
 geocore_link_libraries(${PROJECT_NAME}

--- a/generator/feature_maker_base.cpp
+++ b/generator/feature_maker_base.cpp
@@ -10,10 +10,10 @@ using namespace feature;
 
 namespace generator
 {
-FeatureMakerBase::FeatureMakerBase(std::shared_ptr<cache::IntermediateData> const & cache)
+FeatureMakerBase::FeatureMakerBase(std::shared_ptr<cache::IntermediateData const> const & cache)
   : m_cache(cache) {}
 
-void FeatureMakerBase::SetCache(std::shared_ptr<cache::IntermediateData> const & cache)
+void FeatureMakerBase::SetCache(std::shared_ptr<cache::IntermediateData const> const & cache)
 {
   m_cache = cache;
 }

--- a/generator/feature_maker_base.hpp
+++ b/generator/feature_maker_base.hpp
@@ -19,12 +19,12 @@ class IntermediateData;
 class FeatureMakerBase
 {
 public:
-  explicit FeatureMakerBase(std::shared_ptr<cache::IntermediateData> const & cache = {});
+  explicit FeatureMakerBase(std::shared_ptr<cache::IntermediateData const> const & cache = {});
   virtual ~FeatureMakerBase() = default;
 
   virtual std::shared_ptr<FeatureMakerBase> Clone() const = 0;
 
-  void SetCache(std::shared_ptr<cache::IntermediateData> const & cache);
+  void SetCache(std::shared_ptr<cache::IntermediateData const> const & cache);
 
   // Reference on element is non const because ftype::GetNameAndType will be call.
   virtual bool Add(OsmElement & element);
@@ -40,7 +40,7 @@ protected:
 
   virtual void ParseParams(FeatureParams & params, OsmElement & element) const  = 0;
 
-  std::shared_ptr<cache::IntermediateData> m_cache;
+  std::shared_ptr<cache::IntermediateData const> m_cache;
   std::queue<feature::FeatureBuilder> m_queue;
 };
 

--- a/generator/generate_info.hpp
+++ b/generator/generate_info.hpp
@@ -41,7 +41,6 @@ struct GenerateInfo
 
   unsigned int m_threadsCount{1};
 
-  bool m_preloadCache = false;
   bool m_verbose = false;
 
   GenerateInfo() = default;

--- a/generator/generator_tests/intermediate_data_test.cpp
+++ b/generator/generator_tests/intermediate_data_test.cpp
@@ -185,7 +185,7 @@ void TestIntermediateDataGeneration(
 
         auto osmElements =
             ReadOsmElements(genInfo.m_osmFileName, osmFormatParsers.at(osmFileTypeExtension));
-        auto const & intermediateData = cache::IntermediateData{genInfo, true /* forceReload */};
+        auto const & intermediateData = cache::IntermediateData{genInfo};
         auto const & cache = intermediateData.GetCache();
         dataTester(osmElements, *cache);
       }

--- a/generator/intermediate_data.cpp
+++ b/generator/intermediate_data.cpp
@@ -547,9 +547,9 @@ shared_ptr<IntermediateDataReader> const & IntermediateData::GetCache() const
   return m_reader;
 }
 
-shared_ptr<IntermediateData> IntermediateData::Clone() const
+shared_ptr<IntermediateData const> IntermediateData::Clone() const
 {
-  return make_shared<IntermediateData>(m_info);
+  return shared_from_this();
 }
 }  // namespace cache
 }  // namespace generator

--- a/generator/intermediate_data.hpp
+++ b/generator/intermediate_data.hpp
@@ -366,12 +366,11 @@ CreatePointStorageReader(feature::GenerateInfo::NodeStorageType type, std::strin
 std::unique_ptr<PointStorageWriterInterface>
 CreatePointStorageWriter(feature::GenerateInfo::NodeStorageType type, std::string const & name);
 
-class IntermediateData : public std::enable_shared_from_this<IntermediateData>
+class IntermediateData
 {
 public:
   explicit IntermediateData(feature::GenerateInfo const & info);
   std::shared_ptr<IntermediateDataReader> const & GetCache() const;
-  std::shared_ptr<IntermediateData const> Clone() const;
 
 private:
   feature::GenerateInfo const & m_info;

--- a/generator/raw_generator.cpp
+++ b/generator/raw_generator.cpp
@@ -29,11 +29,6 @@ RawGenerator::RawGenerator(feature::GenerateInfo & genInfo, size_t chunkSize)
 {
 }
 
-void RawGenerator::ForceReloadCache()
-{
-  m_cache = std::make_shared<cache::IntermediateData>(m_genInfo, true /* forceReload */);
-}
-
 std::shared_ptr<FeatureProcessorQueue> RawGenerator::GetQueue()
 {
   return m_queue;

--- a/generator/raw_generator.cpp
+++ b/generator/raw_generator.cpp
@@ -223,11 +223,11 @@ boost::iostreams::mapped_file_source RawGenerator::MakeFileMap(std::string const
   if (!fileMap.is_open())
     MYTHROW(Writer::OpenException, ("Failed to open", filename));
 
-  // Try aggressively (MADV_WILLNEED) and asynchronously (std::launch::async) read ahead
-  // the o5m-file.
-  std::async(std::launch::async, [data = fileMap.data(), size = fileMap.size()] {
+  // Try aggressively (MADV_WILLNEED) and asynchronously read ahead the o5m-file.
+  auto readaheadTask = std::thread([data = fileMap.data(), size = fileMap.size()] {
     ::madvise(const_cast<char*>(data), size, MADV_WILLNEED);
   });
+  readaheadTask.detach();
 
   return fileMap;
 }

--- a/generator/raw_generator.hpp
+++ b/generator/raw_generator.hpp
@@ -35,7 +35,6 @@ public:
   bool Execute();
   std::vector<std::string> const & GetNames() const;
   std::shared_ptr<FeatureProcessorQueue> GetQueue();
-  void ForceReloadCache();
 
 private:
   using FinalProcessorPtr = std::shared_ptr<FinalProcessorIntermediateMwmInterface>;

--- a/generator/raw_generator.hpp
+++ b/generator/raw_generator.hpp
@@ -57,7 +57,7 @@ private:
 
   feature::GenerateInfo & m_genInfo;
   size_t m_chunkSize;
-  std::shared_ptr<cache::IntermediateData> m_cache;
+  std::shared_ptr<cache::IntermediateData const> m_cache;
   std::shared_ptr<FeatureProcessorQueue> m_queue;
   std::shared_ptr<TranslatorCollection> m_translators;
   std::priority_queue<FinalProcessorPtr, std::vector<FinalProcessorPtr>, FinalProcessorPtrCmp> m_finalProcessors;

--- a/generator/translator.cpp
+++ b/generator/translator.cpp
@@ -11,7 +11,7 @@ using namespace feature;
 namespace generator
 {
 Translator::Translator(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                       std::shared_ptr<cache::IntermediateData> const & cache,
+                       std::shared_ptr<cache::IntermediateData const> const & cache,
                        std::shared_ptr<FeatureMakerBase> const & maker,
                        std::shared_ptr<FilterInterface> const & filter,
                        std::shared_ptr<CollectorInterface> const & collector)
@@ -26,7 +26,7 @@ Translator::Translator(std::shared_ptr<FeatureProcessorInterface> const & proces
 }
 
 Translator::Translator(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                       std::shared_ptr<cache::IntermediateData> const & cache,
+                       std::shared_ptr<cache::IntermediateData const> const & cache,
                        std::shared_ptr<FeatureMakerBase> const & maker)
   : Translator(processor, cache, maker, std::make_shared<FilterCollection>(), std::make_shared<CollectorCollection>())
 {

--- a/generator/translator.hpp
+++ b/generator/translator.hpp
@@ -27,12 +27,12 @@ class Translator : public TranslatorInterface
 {
 public:
   explicit Translator(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                      std::shared_ptr<cache::IntermediateData> const & cache,
+                      std::shared_ptr<cache::IntermediateData const> const & cache,
                       std::shared_ptr<FeatureMakerBase> const & maker,
                       std::shared_ptr<FilterInterface> const & filter,
                       std::shared_ptr<CollectorInterface> const & collector);
   explicit Translator(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                      std::shared_ptr<cache::IntermediateData> const & cache,
+                      std::shared_ptr<cache::IntermediateData const> const & cache,
                       std::shared_ptr<FeatureMakerBase> const & maker);
 
   void SetCollector(std::shared_ptr<CollectorInterface> const & collector);
@@ -66,6 +66,6 @@ protected:
   RelationTagsEnricher m_tagsEnricher;
   std::shared_ptr<FeatureMakerBase> m_featureMaker;
   std::shared_ptr<FeatureProcessorInterface> m_processor;
-  std::shared_ptr<cache::IntermediateData> m_cache;
+  std::shared_ptr<cache::IntermediateData const> m_cache;
 };
 }  // namespace generator

--- a/generator/translator.hpp
+++ b/generator/translator.hpp
@@ -47,7 +47,7 @@ protected:
   template <typename T>
   decltype(auto) CloneBase() const
   {
-    auto cache = m_cache->Clone();
+    auto cache = m_cache;
     auto processor = m_processor->Clone();
     auto featureMaker = m_featureMaker->Clone();
     auto filter = m_filter->Clone();

--- a/generator/translator_geo_objects.cpp
+++ b/generator/translator_geo_objects.cpp
@@ -11,8 +11,9 @@
 
 namespace generator
 {
-TranslatorGeoObjects::TranslatorGeoObjects(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                                           std::shared_ptr<cache::IntermediateData> const & cache)
+TranslatorGeoObjects::TranslatorGeoObjects(
+    std::shared_ptr<FeatureProcessorInterface> const & processor,
+    std::shared_ptr<cache::IntermediateData const> const & cache)
   : Translator(processor, cache, std::make_shared<FeatureMakerSimple>(cache))
 
 {

--- a/generator/translator_geo_objects.hpp
+++ b/generator/translator_geo_objects.hpp
@@ -18,7 +18,7 @@ class TranslatorGeoObjects : public Translator
 {
 public:
   explicit TranslatorGeoObjects(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                                std::shared_ptr<cache::IntermediateData> const & cache);
+                                std::shared_ptr<cache::IntermediateData const> const & cache);
 
   // TranslatorInterface overrides:
   std::shared_ptr<TranslatorInterface> Clone() const override;

--- a/generator/translator_region.cpp
+++ b/generator/translator_region.cpp
@@ -52,7 +52,7 @@ public:
 }  // namespace
 
 TranslatorRegion::TranslatorRegion(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                                   std::shared_ptr<cache::IntermediateData> const & cache,
+                                   std::shared_ptr<cache::IntermediateData const> const & cache,
                                    std::string const & regionsInfoPath)
   : Translator(processor, cache, std::make_shared<FeatureMakerSimple>(cache))
 

--- a/generator/translator_region.hpp
+++ b/generator/translator_region.hpp
@@ -22,7 +22,7 @@ class TranslatorRegion : public Translator
 {
 public:
   explicit TranslatorRegion(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                            std::shared_ptr<cache::IntermediateData> const & cache,
+                            std::shared_ptr<cache::IntermediateData const> const & cache,
                             std::string const & regionsInfoPath);
 
   // TranslatorInterface overrides:

--- a/generator/translator_streets.cpp
+++ b/generator/translator_streets.cpp
@@ -7,8 +7,9 @@
 
 namespace generator
 {
-TranslatorStreets::TranslatorStreets(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                                     std::shared_ptr<cache::IntermediateData> const & cache)
+TranslatorStreets::TranslatorStreets(
+    std::shared_ptr<FeatureProcessorInterface> const & processor,
+    std::shared_ptr<cache::IntermediateData const> const & cache)
   : Translator(processor, cache, std::make_shared<FeatureMakerSimple>(cache))
 
 {

--- a/generator/translator_streets.hpp
+++ b/generator/translator_streets.hpp
@@ -18,7 +18,7 @@ class TranslatorStreets : public Translator
 {
 public:
   explicit TranslatorStreets(std::shared_ptr<FeatureProcessorInterface> const & processor,
-                             std::shared_ptr<cache::IntermediateData> const & cache);
+                             std::shared_ptr<cache::IntermediateData const> const & cache);
 
   // TranslatorInterface overrides:
   std::shared_ptr<TranslatorInterface> Clone() const override;


### PR DESCRIPTION
nodes, ways и relations файлы полностью загружаются в память (ways и relations через mmap()), что позволяет шарить геттеры этих объектов тредам (конвертир. o5m в фичи) и избавиться от lseek() + read() для формирования границ фич

Ускорение генерации features-файлов из o5m-файла на ~36% (на ~22 минуты)
до
```
real    61m2.935s
user    1131m40.882s
sys     107m21.045s
```
после
```
real    39m19.132s
user    1077m17.312s
sys     81m6.945s
```