### PR TITLE
[generator:features] Speedup features generation: reuse vector's

### DIFF
--- a/generator/affiliation.cpp
+++ b/generator/affiliation.cpp
@@ -4,12 +4,14 @@ namespace feature
 {
 SingleAffiliation::SingleAffiliation(std::string const & filename)
   : m_filename(filename)
+  , m_affilations{std::make_shared<std::vector<std::string>>(std::vector<std::string>{m_filename})}
 {
 }
 
-std::vector<std::string> SingleAffiliation::GetAffiliations(FeatureBuilder const &) const
+std::shared_ptr<std::vector<std::string>> SingleAffiliation::GetAffiliations(
+    FeatureBuilder const &) const
 {
-  return {m_filename};
+  return m_affilations;
 }
 
 bool SingleAffiliation::HasRegionByName(std::string const & name) const

--- a/generator/affiliation.hpp
+++ b/generator/affiliation.hpp
@@ -13,7 +13,8 @@ public:
   virtual ~AffiliationInterface() = default;
 
   // The method will return the names of the buckets to which the fb belongs.
-  virtual std::vector<std::string> GetAffiliations(FeatureBuilder const & fb) const = 0;
+  virtual std::shared_ptr<std::vector<std::string>> GetAffiliations(
+      FeatureBuilder const & fb) const = 0;
   virtual bool HasRegionByName(std::string const & name) const = 0;
 };
 
@@ -23,10 +24,11 @@ public:
   SingleAffiliation(std::string const & filename);
 
   // AffiliationInterface overrides:
-  std::vector<std::string> GetAffiliations(FeatureBuilder const &) const override;
+  std::shared_ptr<std::vector<std::string>> GetAffiliations(FeatureBuilder const &) const override;
   bool HasRegionByName(std::string const & name) const override;
 
 private:
   std::string m_filename;
+  std::shared_ptr<std::vector<std::string>> m_affilations;
 };
 }  // namespace feature

--- a/generator/features_processing_helpers.hpp
+++ b/generator/features_processing_helpers.hpp
@@ -5,24 +5,22 @@
 #include "base/thread_safe_queue.hpp"
 
 #include <cstddef>
-#include <utility>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace generator
 {
-size_t static const kAffiliationsBufferSize = 512;
+size_t static const kAffiliationsBufferSize = 2'000;
 
 struct ProcessedData
 {
-  explicit ProcessedData(feature::FeatureBuilder::Buffer && buffer,
-                         std::vector<std::string> && affiliations)
-    : m_buffer(std::move(buffer)), m_affiliations(std::move(affiliations)) {}
-
   feature::FeatureBuilder::Buffer m_buffer;
-  std::vector<std::string> m_affiliations;
+  std::shared_ptr<std::vector<std::string>> m_affiliations;
 };
 
-using FeatureProcessorChunk = base::threads::DataWrapper<std::vector<ProcessedData>>;
+using FeatureProcessorChunk =
+    base::threads::DataWrapper<std::shared_ptr<std::vector<ProcessedData>>>;
 using FeatureProcessorQueue = base::threads::ThreadSafeQueue<FeatureProcessorChunk>;
 }  // namespace generator

--- a/generator/generator_tests/intermediate_data_test.cpp
+++ b/generator/generator_tests/intermediate_data_test.cpp
@@ -170,7 +170,7 @@ void TestIntermediateDataGeneration(
     auto const & osmFileData = sample.second;
 
     // Skip test for node storage type "mem": 64Gb required.
-    for (auto const & nodeStorageType : {"raw"s, "map"s, "mem"s})
+    for (auto const & nodeStorageType : {"raw"s, "map"s})
     {
       for (auto threadsCount : {1, 2, 4})
       {

--- a/generator/processor_simple.cpp
+++ b/generator/processor_simple.cpp
@@ -31,7 +31,7 @@ void ProcessorSimple::Process(feature::FeatureBuilder & fb)
 
 void ProcessorSimple::Finish()
 {
-  m_affiliationsLayer->AddBufferToQueue();
+  m_affiliationsLayer->Flush();
 }
 
 void ProcessorSimple::Merge(FeatureProcessorInterface const & other)

--- a/generator/raw_generator_writer.cpp
+++ b/generator/raw_generator_writer.cpp
@@ -30,7 +30,7 @@ void RawGeneratorWriter::Run()
       if (chunk.IsEmpty())
         return;
 
-      Write(chunk.Get());
+      Write(*chunk.Get());
     }
   });
 }
@@ -51,7 +51,7 @@ void RawGeneratorWriter::Write(std::vector<ProcessedData> const & vecChunks)
 {
   for (auto const & chunk : vecChunks)
   {
-    for (auto const & affiliation : chunk.m_affiliations)
+    for (auto const & affiliation : *chunk.m_affiliations)
     {
       if (affiliation.empty())
         continue;


### PR DESCRIPTION
Минимизация расхода памяти.

При генерации фич из o5m файла, сами фичи формируются в пуле тредов чтения o5m файла, а записываются один тредом-писателем. Читатели выделяют память для каждой фичи и передают их треду-писателю через очередь. Получается, что память выделяется в нескольких тредах, а освобождается только в одном. Освобождённая память возвр. в общий пул, только при достижении опред. порога, но этот порог слишком высок для нас (в случае tcmalloc) т.к. в процесс ещё отображено порядка 180 GB данных из файлов (o5m, nodes, ways, relations) и буфера файлов частично вытесняются.

Тек. PR минимизирует аллокации векторов под фич, и освобождение памяти происх. в том же треде, что и аллокация.