### PR TITLE
[generator] Speedup generation: features file parallel reading

### DIFF
--- a/generator/feature_generator.cpp
+++ b/generator/feature_generator.cpp
@@ -95,38 +95,6 @@ uint32_t FeaturesCollector::Collect(FeatureBuilder const & fb)
   return featureId;
 }
 
-FeaturesAndRawGeometryCollector::FeaturesAndRawGeometryCollector(std::string const & featuresFileName,
-                                                                 std::string const & rawGeometryFileName)
-  : FeaturesCollector(featuresFileName), m_rawGeometryFileStream(rawGeometryFileName) {}
-
-FeaturesAndRawGeometryCollector::~FeaturesAndRawGeometryCollector()
-{
-  uint64_t terminator = 0;
-  m_rawGeometryFileStream.Write(&terminator, sizeof(terminator));
-  LOG(LINFO, ("Write", m_rawGeometryCounter, "geometries into", m_rawGeometryFileStream.GetName()));
-}
-
-uint32_t FeaturesAndRawGeometryCollector::Collect(FeatureBuilder const & fb)
-{
-  uint32_t const featureId = FeaturesCollector::Collect(fb);
-  FeatureBuilder::Geometry const & geom = fb.GetGeometry();
-  if (geom.empty())
-    return featureId;
-
-  ++m_rawGeometryCounter;
-
-  uint64_t numGeometries = geom.size();
-  m_rawGeometryFileStream.Write(&numGeometries, sizeof(numGeometries));
-  for (FeatureBuilder::PointSeq const & points : geom)
-  {
-    uint64_t numPoints = points.size();
-    m_rawGeometryFileStream.Write(&numPoints, sizeof(numPoints));
-    m_rawGeometryFileStream.Write(points.data(),
-                                  sizeof(FeatureBuilder::PointSeq::value_type) * points.size());
-  }
-  return featureId;
-}
-
 uint32_t CheckedFilePosCast(FileWriter const & f)
 {
   uint64_t pos = f.Pos();

--- a/generator/feature_generator.hpp
+++ b/generator/feature_generator.hpp
@@ -55,18 +55,5 @@ private:
   uint32_t m_featureID = 0;
 };
 
-class FeaturesAndRawGeometryCollector : public FeaturesCollector
-{
-  FileWriter m_rawGeometryFileStream;
-  size_t m_rawGeometryCounter = 0;
-
-public:
-  FeaturesAndRawGeometryCollector(std::string const & featuresFileName,
-                                  std::string const & rawGeometryFileName);
-  ~FeaturesAndRawGeometryCollector() override;
-
-  uint32_t Collect(FeatureBuilder const & f) override;
-};
-
 uint32_t CheckedFilePosCast(FileWriter const & f);
 }  // namespace feature


### PR DESCRIPTION
Независимое параллельное чтение файла фич.

Ускорение стадии генерации jsonl улиц ~35% (на ~1:20):
до
```
real    227m24.854s
user    1549m42.915s
sys     388m24.990s
```
после
```
real    148m10.524s
user    1292m27.816s
sys     134m17.200s
```

На стадию генерации geo_objects не сказалось, в доступ к общим ресурсов упирается. Но этот фикс сработает, когда это узкое горлышко устранится.