### PR TITLE
[generator:regions] Fix Hawai as country: ignore enclave ways

### DIFF
--- a/generator/generator_tests/common.cpp
+++ b/generator/generator_tests/common.cpp
@@ -39,10 +39,10 @@ OsmElement MakeOsmElement(OsmElementData const & elementData)
   OsmElement el;
   el.m_id = elementData.m_id;
 
+  if (!el.m_members.empty())
+    el.m_type = OsmElement::EntityType::Relation;
   if (elementData.m_points.size() == 1)
     el.m_type = OsmElement::EntityType::Node;
-  else if (elementData.m_points.front() == elementData.m_points.back())
-    el.m_type = OsmElement::EntityType::Relation;
   else
     el.m_type = OsmElement::EntityType::Way;
 

--- a/generator/generator_tests/regions_tests.cpp
+++ b/generator/generator_tests/regions_tests.cpp
@@ -7,6 +7,7 @@
 #include "generator/regions/collector_region_info.hpp"
 #include "generator/regions/place_point.hpp"
 #include "generator/regions/regions_builder.hpp"
+#include "generator/translator_region.hpp"
 
 #include "indexer/classificator.hpp"
 #include "indexer/classificator_loader.hpp"
@@ -635,4 +636,34 @@ UNIT_TEST(RegionsBuilderTest_GenerateRusSPetersburgSuburb)
                u8"Россия, region: Санкт-Петербург, locality: Санкт-Петербург, "
                u8"suburb: Центральный район, sublocality: Дворцовый округ"),
        ());
+}
+
+// Enclave way ignoring tests ----------------------------------------------------------------------
+UNIT_TEST(RegionsFilterTest_EnclaveWayIgnoring)
+{
+  auto usa = OsmElement{};
+  usa.m_type = OsmElement::EntityType::Relation;
+  usa.m_id = 1;
+  usa.m_nodes = {1, 2, 3, 1};
+  usa.m_tags = {
+    {"name", u8"United States of America"},
+    {"type", "boundary"},
+    {"boundary", "administrative"},
+    {"admin_level", "2"}
+  };
+
+  auto hawai = OsmElement{};
+  hawai.m_type = OsmElement::EntityType::Way;
+  hawai.m_id = 2;
+  hawai.m_nodes = {1, 2, 3, 1};
+  hawai.m_tags = {
+    {"name", u8"United States of America (Island of Hawai'i territorial waters)"},
+    {"boundary", "administrative"},
+    {"admin_level", "2"}
+  };
+
+  auto && regionsFilter = FilterRegions{};
+
+  TEST(regionsFilter.IsAccepted(usa), ());
+  TEST(!regionsFilter.IsAccepted(hawai), ());
 }

--- a/generator/generator_tests/streets_index_tests.cpp
+++ b/generator/generator_tests/streets_index_tests.cpp
@@ -82,5 +82,5 @@ UNIT_TEST(StreetsIndexTest_SquareIndex)
 
   auto inside = GetObjectsAtPoint(streetsIndex, {1.000 + 0.001, 2.000 + 0.001});
   TEST_EQUAL(inside.size(), 1, ());
-  TEST_EQUAL(inside, Objects({MakeOsmRelation(1)}), ());
+  TEST_EQUAL(inside, Objects({MakeOsmWay(1)}), ());
 }

--- a/generator/translator_region.hpp
+++ b/generator/translator_region.hpp
@@ -7,7 +7,7 @@
 
 namespace feature
 {
-struct GenerateInfo;
+class FeatureBuilder;
 }  // namespace feature
 
 namespace cache
@@ -33,5 +33,18 @@ public:
 
 protected:
   using Translator::Translator;
+};
+
+class FilterRegions : public FilterInterface
+{
+public:
+  // FilterInterface overrides:
+  std::shared_ptr<FilterInterface> Clone() const override;
+  bool IsAccepted(OsmElement const & element) override;
+  bool IsAccepted(feature::FeatureBuilder const & feature) override;
+
+protected:
+  bool IsEnclaveBoundaryWay(OsmElement const & element) const;
+  bool IsGeometryClosed(OsmElement const & element) const;
 };
 }  // namespace generator


### PR DESCRIPTION
Игнорировать `way` с именем и `admin_level=2`, как границу страны с указанным именем. Правильная граница страны должна быть `relation` и иметь `type=boundary`