### PR TITLE
[generator:geo_objects] Add parallel KV write

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -55,6 +55,8 @@ set(
   intermediate_data.cpp
   intermediate_data.hpp
   intermediate_elements.hpp
+  key_value_concurrent_writer.cpp
+  key_value_concurrent_writer.hpp
   key_value_storage.cpp
   key_value_storage.hpp
   locality_sorter.cpp

--- a/generator/generator_tests/geo_objects_tests.cpp
+++ b/generator/generator_tests/geo_objects_tests.cpp
@@ -153,7 +153,6 @@ void TestFindReverse(std::vector<OsmElementData> const & osmElements,
     TestRegionAddress(json.get());
     TEST(JsonHasBuilding(JsonValue{std::move(json)}), ("No address for", id));
   }
-  geoObjectsGenerator->GetMaintainer().Flush();
 
   KeyValueStorage kvStorage{geoObjectsKeyValue.GetFullPath(), 0 /*cacheValuesCountLimit*/};
 
@@ -241,8 +240,6 @@ void TestPoiHasAddress(std::vector<OsmElementData> const & osmElements)
 
   std::unique_ptr<GeoObjectsGenerator> geoObjectsGenerator = {
       TearUp(osmElements, geoObjectsFeatures, idsWithoutAddresses, geoObjectsKeyValue)};
-
-  geoObjectsGenerator->GetMaintainer().Flush();
 
   KeyValueStorage kvStorage{geoObjectsKeyValue.GetFullPath(), 0 /*cacheValuesCountLimit*/};
 

--- a/generator/geo_objects/geo_objects.hpp
+++ b/generator/geo_objects/geo_objects.hpp
@@ -15,12 +15,15 @@
 
 #include <string>
 
+#include <boost/optional.hpp>
+
 namespace generator
 {
 namespace geo_objects
 {
 
 using IndexReader = ReaderPtr<Reader>;
+using RegionInfoLocater = std::function<boost::optional<KeyValue>(m2::PointD const & pathPoint)>;
 
 boost::optional<indexer::GeoObjectsIndex<IndexReader>> MakeTempGeoObjectsIndex(
     std::string const & pathToGeoObjectsTmpMwm);
@@ -28,7 +31,8 @@ boost::optional<indexer::GeoObjectsIndex<IndexReader>> MakeTempGeoObjectsIndex(
 bool JsonHasBuilding(JsonValue const & json);
 
 void AddBuildingsAndThingsWithHousesThenEnrichAllWithRegionAddresses(
-    GeoObjectMaintainer & geoObjectMaintainer, std::string const & pathInGeoObjectsTmpMwm,
+    std::string const & geoObjectKeyValuePath, GeoObjectMaintainer & geoObjectMaintainer,
+    std::string const & pathInGeoObjectsTmpMwm, RegionInfoLocater const & regionInfoLocater,
     bool verbose, unsigned int threadsCount);
 
 struct NullBuildingsInfo
@@ -46,6 +50,7 @@ NullBuildingsInfo EnrichPointsWithOuterBuildingGeometry(
 
 void AddPoisEnrichedWithHouseAddresses(GeoObjectMaintainer & geoObjectMaintainer,
                                        NullBuildingsInfo const & buildingsInfo,
+                                       std::string const & geoObjectKeyValuePath,
                                        std::string const & pathInGeoObjectsTmpMwm,
                                        std::ostream & streamPoiIdsToAddToLocalityIndex,
                                        bool verbose, unsigned int threadsCount);

--- a/generator/geo_objects/geo_objects_generator.hpp
+++ b/generator/geo_objects/geo_objects_generator.hpp
@@ -18,7 +18,7 @@ namespace geo_objects
 class GeoObjectsGenerator
 {
 public:
-  GeoObjectsGenerator(GeoObjectMaintainer::RegionInfoGetter && regionInfoGetter,
+  GeoObjectsGenerator(RegionInfoLocater && regionInfoLocater,
                       GeoObjectMaintainer::RegionIdGetter && regionIdGetter,
                       std::string pathInGeoObjectsTmpMwm, std::string pathOutIdsWithoutAddress,
                       std::string pathOutGeoObjectsKv,
@@ -45,6 +45,7 @@ private:
   bool m_verbose = false;
   unsigned int m_threadsCount = 1;
   GeoObjectMaintainer m_geoObjectMaintainer;
+  RegionInfoLocater m_regionInfoLocater;
 };
 
 bool GenerateGeoObjects(std::string const & regionsIndex, std::string const & regionsKeyValue,

--- a/generator/key_value_concurrent_writer.cpp
+++ b/generator/key_value_concurrent_writer.cpp
@@ -1,0 +1,76 @@
+#include "generator/key_value_concurrent_writer.hpp"
+
+#include "generator/key_value_storage.hpp"
+
+#include <cstring>
+#include <stdexcept>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+namespace generator
+{
+KeyValueConcurrentWriter::KeyValueConcurrentWriter(
+    std::string const & keyValuePath, size_t bufferSize)
+  : m_bufferSize{bufferSize}
+{
+  // Posix API are used for concurrent atomic write from threads.
+  ::mode_t mode{S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH};
+  m_keyValueFile = ::open(keyValuePath.c_str(), O_CREAT | O_WRONLY | O_APPEND, mode);
+  if (m_keyValueFile == -1)
+  {
+    throw std::runtime_error("failed to open file " + keyValuePath + ": " +
+                             std::strerror(errno));
+  }
+}
+  
+KeyValueConcurrentWriter::KeyValueConcurrentWriter(KeyValueConcurrentWriter && other)
+{
+  *this = std::move(other);
+}
+
+KeyValueConcurrentWriter & KeyValueConcurrentWriter::operator=(
+    KeyValueConcurrentWriter && other)
+{
+  if (m_keyValueFile != -1)
+  {
+    FlushBuffer();
+    ::close(m_keyValueFile);
+    m_keyValueFile = -1;
+  }
+
+  std::swap(m_keyValueFile, other.m_keyValueFile);
+  m_keyValueBuffer = std::move(other.m_keyValueBuffer);
+  m_bufferSize = other.m_bufferSize;
+  return *this;
+}
+
+KeyValueConcurrentWriter::~KeyValueConcurrentWriter()
+{
+  if (m_keyValueFile == -1)
+    return;
+
+  FlushBuffer();
+  ::close(m_keyValueFile);
+}
+
+void KeyValueConcurrentWriter::Write(base::GeoObjectId const & id, JsonValue const & jsonValue)
+{
+  KeyValueStorage::SerializeFullLine(m_keyValueBuffer, id.GetEncodedId(), jsonValue);
+
+  if (size_t{m_keyValueBuffer.tellp()} + 1'000 >= m_bufferSize)
+    FlushBuffer();
+}
+
+void KeyValueConcurrentWriter::FlushBuffer()
+{
+  auto const & data = m_keyValueBuffer.str();
+  if (data.empty())
+    return;
+
+  auto writed = ::write(m_keyValueFile, data.data(), data.size());
+  // Error if ::write() interrupted by a signal.
+  CHECK(static_cast<size_t>(writed) == data.size(), ());
+  m_keyValueBuffer.str({});
+}
+}  // namespace generator

--- a/generator/key_value_concurrent_writer.hpp
+++ b/generator/key_value_concurrent_writer.hpp
@@ -1,0 +1,30 @@
+#include "generator/key_value_storage.hpp"
+
+#include "base/geo_object_id.hpp"
+
+#include <string>
+#include <sstream>
+
+namespace generator
+{
+// |KeyValueConcurrentWriter| allow concurrent write to the same KV-file by multiple instance of
+// this class from threads.
+class KeyValueConcurrentWriter
+{
+public:
+  KeyValueConcurrentWriter(std::string const & keyValuePath, size_t bufferSize = 1'000'000);
+  KeyValueConcurrentWriter(KeyValueConcurrentWriter && other);
+  KeyValueConcurrentWriter & operator=(KeyValueConcurrentWriter && other);
+  ~KeyValueConcurrentWriter();
+
+  // No thread-safety.
+  void Write(base::GeoObjectId const & id, JsonValue const & jsonValue);
+
+private:
+  int m_keyValueFile{-1};
+  std::ostringstream m_keyValueBuffer;
+  size_t m_bufferSize{1'000'000};
+
+  void FlushBuffer();
+};
+}  // namespace generator

--- a/generator/key_value_storage.hpp
+++ b/generator/key_value_storage.hpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -20,11 +21,11 @@ public:
   explicit JsonValue(json_t * value = nullptr) : m_handle{value} {}
   explicit JsonValue(base::JSONPtr && value) : m_handle{std::move(value)} {}
 
-  JsonValue(JsonValue const &) = delete;
-  JsonValue & operator=(JsonValue const &) = delete;
+  JsonValue(JsonValue &&) = default;
+  JsonValue & operator=(JsonValue &&) = default;
 
   operator json_t const *() const noexcept { return m_handle.get(); }
-  operator base::JSONPtr const &() noexcept { return m_handle; };
+  operator base::JSONPtr const &() const noexcept { return m_handle; };
   base::JSONPtr MakeDeepCopyJson() const { return base::JSONPtr{json_deep_copy(m_handle.get())}; }
 
 private:
@@ -52,9 +53,8 @@ public:
   KeyValueStorage(KeyValueStorage const &) = delete;
   KeyValueStorage & operator=(KeyValueStorage const &) = delete;
 
-  void Insert(uint64_t key, JsonValue && valueJson);
-
-  static std::string SerializeFullLine(uint64_t key, JsonValue && valueJson);
+  static std::string SerializeFullLine(uint64_t key, JsonValue const & valueJson);
+  static void SerializeFullLine(std::ostream & out, uint64_t key, JsonValue const & jsonValue);
 
   std::shared_ptr<JsonValue> Find(uint64_t key) const;
   size_t Size() const;
@@ -72,7 +72,6 @@ private:
   static bool DefaultPred(KeyValue const &) { return true; }
   static bool ParseKeyValueLine(std::string const & line, std::streamoff lineNumber, uint64_t & key,
                                 std::string & value);
-  std::fstream m_storage;
   std::unordered_map<uint64_t, Value> m_values;
   size_t m_cacheValuesCountLimit;
 };


### PR DESCRIPTION
Параллельная запись KV-фала из тредов (`class KeyValueConcurrentWriter`).
Минимизация конкуренции обновления контейнера кеша адресов (`class BufferedCuncurrentUnorderedMapUpdater`).

Ускорение подстадии генерации объектов с адресами `geo_objects.jsonl` на ~15-20 раз (40 минут vs 14-19 часов).