### PR TITLE
[geocoder] Fix rank for house number candidate with extra tokens

### DIFF
--- a/geocoder/geocoder.cpp
+++ b/geocoder/geocoder.cpp
@@ -150,13 +150,6 @@ strings::UniString MakeHouseNumber(Tokens const & tokens)
 {
   return strings::MakeUniString(strings::JoinStrings(tokens, " "));
 }
-
-strings::UniString & AppendToHouseNumber(strings::UniString & houseNumber, std::string const & token)
-{
-  houseNumber += strings::MakeUniString(" ");
-  houseNumber += strings::MakeUniString(token);
-  return houseNumber;
-}
 }  // namespace
 
 // Geocoder::Layer ---------------------------------------------------------------------------------
@@ -522,7 +515,7 @@ void Geocoder::FillBuildingsLayer(
           if (!parentCandidateCertainty)
             return;
 
-          auto totalCertainty =
+          auto const totalCertainty =
               *parentCandidateCertainty + SumHouseNumberSubqueryCertainty(matchResult);
           auto const isOtherSimilar =
               matchResult.queryMismatchedTokensCount || matchResult.houseNumberMismatchedTokensCount;
@@ -554,9 +547,9 @@ void Geocoder::FillRegularLayer(Context const & ctx, Type type, Tokens const & s
     if (type > Type::Locality && !IsRelevantLocalityMember(ctx, d, subquery))
       return;
 
-    auto subqueryWeight =
+    auto const subqueryWeight =
         (d.m_kind != Kind::Unknown ? GetWeight(d.m_kind) : GetWeight(d.m_type)) * subquery.size();
-    auto totalCertainty = *parentCandidateCertainty + subqueryWeight;
+    auto const totalCertainty = *parentCandidateCertainty + subqueryWeight;
 
     candidates.push_back({docId, totalCertainty, false /* m_isOtherSimilar */});
   });
@@ -608,7 +601,8 @@ bool Geocoder::IsValidHouseNumberWithNextUnusedToken(
     return false;
 
   auto subqueryHouseNumber = MakeHouseNumber(subquery);
-  AppendToHouseNumber(subqueryHouseNumber, ctx.GetToken(nextTokenPos));
+  subqueryHouseNumber += strings::MakeUniString(" ");
+  subqueryHouseNumber += strings::MakeUniString(ctx.GetToken(nextTokenPos));
 
   return search::house_numbers::LooksLikeHouseNumber(subqueryHouseNumber, false /* isPrefix */);
 }

--- a/geocoder/geocoder.hpp
+++ b/geocoder/geocoder.hpp
@@ -81,11 +81,11 @@ public:
   public:
     struct BeamKey
     {
-      BeamKey(base::GeoObjectId osmId, Type type, std::vector<size_t> const & tokenIds,
+      BeamKey(base::GeoObjectId osmId, Type type, std::vector<size_t> const & tokensPositions,
               std::vector<Type> const & allTypes, bool isOtherSimilar)
         : m_osmId(osmId)
         , m_type(type)
-        , m_tokenIds{tokenIds}
+        , m_tokensPositions{tokensPositions}
         , m_allTypes(allTypes)
         , m_isOtherSimilar(isOtherSimilar)
       {
@@ -94,7 +94,7 @@ public:
 
       base::GeoObjectId m_osmId;
       Type m_type;
-      std::vector<size_t> m_tokenIds;
+      std::vector<size_t> m_tokensPositions;
       std::vector<Type> m_allTypes;
       bool m_isOtherSimilar;
     };
@@ -120,7 +120,7 @@ public:
     bool AllTokensUsed() const;
 
     void AddResult(base::GeoObjectId const & osmId, double certainty, Type type,
-                   std::vector<size_t> const & tokenIds, std::vector<Type> const & allTypes,
+                   std::vector<size_t> const & tokensPositions, std::vector<Type> const & allTypes,
                    bool isOtherSimilar);
 
     void FillResults(std::vector<Result> & results) const;
@@ -129,13 +129,14 @@ public:
 
     std::vector<Layer> const & GetLayers() const;
 
-    void MarkHouseNumberPositionsInQuery(std::vector<size_t> const & tokenIds);
+    void MarkHouseNumberPositionsInQuery(std::vector<size_t> const & tokensPositions);
 
   private:
-    bool IsGoodForPotentialHouseNumberAt(BeamKey const & beamKey, std::set<size_t> const & tokenIds) const;
+    bool IsGoodForPotentialHouseNumberAt(BeamKey const & beamKey,
+                                         std::set<size_t> const & tokensPositions) const;
     bool IsBuildingWithAddress(BeamKey const & beamKey) const;
     bool HasLocalityOrRegion(BeamKey const & beamKey) const;
-    bool ContainsTokenIds(BeamKey const & beamKey, std::set<size_t> const & needTokenIds) const;
+    bool ContainsTokens(BeamKey const & beamKey, std::set<size_t> const & needTokensPostions) const;
 
     Tokens m_tokens;
     std::vector<Type> m_tokenTypes;
@@ -179,14 +180,16 @@ public:
 private:
   void Go(Context & ctx, Type type) const;
 
-  void FillBuildingsLayer(Context & ctx, Tokens const & subquery, std::vector<size_t> const & subqueryTokenIds,
+  void FillBuildingsLayer(Context & ctx, Tokens const & subquery,
+                          std::vector<size_t> const & subqueryTokensPositions,
                           Layer & curLayer) const;
   void FillRegularLayer(Context const & ctx, Type type, Tokens const & subquery,
                         Layer & curLayer) const;
   void AddResults(Context & ctx, std::vector<Candidate> const & candidates) const;
 
-  bool IsValidHouseNumberWithNextUnusedToken(Context const & ctx, Tokens const & subquery,
-                                             std::vector<size_t> const & subqueryTokenIds) const;
+  bool IsValidHouseNumberWithNextUnusedToken(
+      Context const & ctx, Tokens const & subquery,
+      std::vector<size_t> const & subqueryTokensPositions) const;
   double SumHouseNumberSubqueryCertainty(
       search::house_numbers::MatchResult const & matchResult) const;
 

--- a/geocoder/geocoder_tests/geocoder_tests.cpp
+++ b/geocoder/geocoder_tests/geocoder_tests.cpp
@@ -39,7 +39,7 @@ void TestGeocoder(Geocoder & geocoder, string const & query, vector<Result> && e
   TEST_EQUAL(actual.size(), expected.size(), (query, actual, expected));
   sort(actual.begin(), actual.end(), base::LessBy(&Result::m_osmId));
   sort(expected.begin(), expected.end(), base::LessBy(&Result::m_osmId));
-  for (size_t i = 0; i < actual.size(); ++i)
+  for (size_t i = 0; i < std::min(actual.size(), expected.size()); ++i)
   {
     TEST(actual[i].m_certainty >= 0.0 && actual[i].m_certainty <= 1.0,
          (query, actual[i].m_certainty));
@@ -155,7 +155,7 @@ UNIT_TEST(Geocoder_MismatchedLocality)
 22 {"properties": {"kind": "building", "locales": {"default": {"address": {"building": "2", "street": "Krymskaya", "locality": "Moscow"}}}}}
 
 31 {"properties": {"kind": "street", "locales": {"default": {"address": {"street": "Krymskaya", "locality": "Paris"}}}}}
-32 {"properties": {"kind": "builidng", "locales": {"default": {"address": {"building": "3", "street": "Krymskaya", "locality": "Paris"}}}}}
+32 {"properties": {"kind": "building", "locales": {"default": {"address": {"building": "3", "street": "Krymskaya", "locality": "Paris"}}}}}
 )#";
 
   Geocoder geocoder;
@@ -314,7 +314,7 @@ UNIT_TEST(Geocoder_BuildingOnStreetWithNumber)
   string const kData = R"#(
 10 {"properties": {"kind": "city", "locales": {"default": {"address": {"locality": "Москва"}}}}}
 13 {"properties": {"kind": "street", "locales": {"default": {"address": {"locality": "Москва", "street": "улица 8 Марта"}}}}}
-15 {"properties": {"kind": "street", "locales": {"default": {"address": {"locality": "Москва", "street": "улица 8 Марта", "building": "4"}}}}}
+15 {"properties": {"kind": "building", "locales": {"default": {"address": {"locality": "Москва", "street": "улица 8 Марта", "building": "4"}}}}}
 )#";
 
   Geocoder geocoder;
@@ -329,7 +329,7 @@ UNIT_TEST(Geocoder_LocalityBuilding)
 {
   string const kData = R"#(
 10 {"properties": {"kind": "city", "locales": {"default": {"address": {"locality": "Zelenograd"}}}}}
-22 {"properties": {"kind": "builiding", "locales": {"default": {"address": {"building": "2", "locality": "Zelenograd"}}}}}
+22 {"properties": {"kind": "building", "locales": {"default": {"address": {"building": "2", "locality": "Zelenograd"}}}}}
 31 {"properties": {"kind": "street", "locales": {"default": {"address": {"street": "Krymskaya", "locality": "Zelenograd"}}}}}
 32 {"properties": {"kind": "building", "locales": {"default": {"address": {"building": "2", "street": "Krymskaya", "locality": "Zelenograd"}}}}}
 )#";
@@ -348,7 +348,7 @@ UNIT_TEST(Geocoder_LocalityBuildingRankWithSuburb)
   string const kData = R"#(
 10 {"properties": {"kind": "city", "locales": {"default": {"address": {"locality": "Москва"}}}}}
 11 {"properties": {"kind": "suburb", "locales": {"default": {"address": {"suburb": "Арбат", "locality": "Москва"}}}}}
-12 {"properties": {"kind": "builidng", "locales": {"default": {"address": {"building": "1", "suburb": "Арбат", "locality": "Москва"}}}}}
+12 {"properties": {"kind": "building", "locales": {"default": {"address": {"building": "1", "suburb": "Арбат", "locality": "Москва"}}}}}
 13 {"properties": {"kind": "suburb", "locales": {"default": {"address": {"suburb": "район Северный", "locality": "Москва"}}}}}
 14 {"properties": {"kind": "building", "locales": {"default": {"address": {"building": "1", "suburb": "район Северный", "locality": "Москва"}}}}}
 )#";

--- a/geocoder/house_numbers_matcher.cpp
+++ b/geocoder/house_numbers_matcher.cpp
@@ -536,7 +536,7 @@ bool HouseNumbersMatch(strings::UniString const & houseNumber, strings::UniStrin
 
 bool HouseNumbersMatch(strings::UniString const & houseNumber, vector<Token> const & queryParse)
 {
-  auto && matchResult = MatchResult{};
+  MatchResult matchResult{};
   return HouseNumbersMatch(houseNumber, queryParse, matchResult);
 }
 

--- a/geocoder/house_numbers_matcher.cpp
+++ b/geocoder/house_numbers_matcher.cpp
@@ -536,14 +536,25 @@ bool HouseNumbersMatch(strings::UniString const & houseNumber, strings::UniStrin
 
 bool HouseNumbersMatch(strings::UniString const & houseNumber, vector<Token> const & queryParse)
 {
+  auto && matchResult = MatchResult{};
+  return HouseNumbersMatch(houseNumber, queryParse, matchResult);
+}
+
+bool HouseNumbersMatch(strings::UniString const & houseNumber, vector<Token> const & queryParse,
+                       MatchResult & matchResult)
+{
   if (houseNumber.empty() || queryParse.empty())
+  {
+    matchResult = {};
     return false;
+  }
 
   // Fast pre-check, helps to early exit without complex house number
   // parsing.
   if (IsASCIIDigit(houseNumber[0]) && IsASCIIDigit(queryParse[0].m_value[0]) &&
       houseNumber[0] != queryParse[0].m_value[0])
   {
+    matchResult = {};
     return false;
   }
 
@@ -554,13 +565,25 @@ bool HouseNumbersMatch(strings::UniString const & houseNumber, vector<Token> con
   {
     if (parse.empty())
       continue;
-    if (parse[0] == queryParse[0] &&
-        (IsSubsequence(parse.begin() + 1, parse.end(), queryParse.begin() + 1, queryParse.end()) ||
-         IsSubsequence(queryParse.begin() + 1, queryParse.end(), parse.begin() + 1, parse.end())))
+    if (parse[0] == queryParse[0])
     {
-      return true;
+      if (IsSubsequence(parse.begin() + 1, parse.end(), queryParse.begin() + 1, queryParse.end()))
+      {
+        matchResult = {queryParse.size(), parse.size() - queryParse.size(),
+                       0 /* queryMismatchedTokensCount */};
+        return true;
+      }
+
+      if (IsSubsequence(queryParse.begin() + 1, queryParse.end(), parse.begin() + 1, parse.end()))
+      {
+        matchResult = {parse.size(), 0 /* houseNumberMismatchedTokensCount */,
+                       queryParse.size() - parse.size()};
+        return true;
+      }
     }
   }
+
+  matchResult = {};
   return false;
 }
 

--- a/geocoder/house_numbers_matcher.hpp
+++ b/geocoder/house_numbers_matcher.hpp
@@ -52,6 +52,13 @@ struct Token
   bool m_prefix = false;
 };
 
+struct MatchResult
+{
+  size_t matchedTokensCount;
+  size_t houseNumberMismatchedTokensCount;
+  size_t queryMismatchedTokensCount;
+};
+
 // Tokenizes |s| that may be a house number.
 void Tokenize(strings::UniString s, bool isPrefix, std::vector<Token> & ts);
 
@@ -69,6 +76,11 @@ bool HouseNumbersMatch(strings::UniString const & houseNumber, strings::UniStrin
 // Returns true if house number matches to a given parsed query.
 bool HouseNumbersMatch(strings::UniString const & houseNumber,
                        std::vector<Token> const & queryParse);
+
+// Returns true if house number matches to a given parsed query.
+// If true is returned then |matchResult| has matching info.
+bool HouseNumbersMatch(strings::UniString const & houseNumber, std::vector<Token> const & queryParse,
+                       MatchResult & matchResult);
 
 // Returns true if |s| looks like a house number.
 bool LooksLikeHouseNumber(strings::UniString const & s, bool isPrefix);


### PR DESCRIPTION
Фикс ранжирования домов, когда запрашивается, например, номер дома "10" и выдаётся два кандидата "10 A" и "10" с неправильными весами: rank == 1 и rank < 1, соответственно.

Ferret ускорился на 30% на тестовой выборке:
до
```
Processed rows                          10000   58.5955
full_matched                            8046    80.46
```
после
```
Processed rows                          10000   41.884321
full_matched                            8045    80.45
```