### PR TITLE
[generator:locidx-building] Speedup: skip middle points

### DIFF
--- a/indexer/feature_visibility.cpp
+++ b/indexer/feature_visibility.cpp
@@ -408,19 +408,6 @@ int GetMinDrawableScale(TypesHolder const & types, m2::RectD limitRect)
   return -1;
 }
 
-int GetMinDrawableScaleGeometryOnly(TypesHolder const & types, m2::RectD limitRect)
-{
-  int const upBound = scales::GetUpperStyleScale();
-
-  for (int level = 0; level <= upBound; ++level)
-  {
-    if (IsDrawableForIndexGeometryOnly(types, limitRect, level))
-      return level;
-  }
-
-  return -1;
-}
-
 int GetMinDrawableScaleClassifOnly(TypesHolder const & types)
 {
   int const upBound = scales::GetUpperStyleScale();

--- a/indexer/feature_visibility.hpp
+++ b/indexer/feature_visibility.hpp
@@ -42,7 +42,6 @@ namespace feature
 
   int GetMinDrawableScale(FeatureType & ft);
   int GetMinDrawableScale(TypesHolder const & types, m2::RectD limitRect);
-  int GetMinDrawableScaleGeometryOnly(TypesHolder const & types, m2::RectD limitRect);
   int GetMinDrawableScaleClassifOnly(TypesHolder const & types);
 
   /// @return [-1, -1] if range is not drawable


### PR DESCRIPTION
Убрал вычисление средних точек фичей. Это наследие от omim, которое нам не нужно.

Ускоряет процесс генерации индекс файла для regions и geo_objects, jsonl для geo_objects.
Например, генерация индекс файла для geo_objects сократилась на 2h:25m