### PR TITLE
[indexer] Fix object covering

### DIFF
--- a/geometry/covering_utils.hpp
+++ b/geometry/covering_utils.hpp
@@ -78,18 +78,18 @@ template <class CellId, class CellIdContainerT, typename IntersectF>
 void CoverObject(IntersectF const & intersect, uint64_t cellPenaltyArea, CellIdContainerT & out,
                  int cellDepth, CellId cell)
 {
-  if (cell.Level() == cellDepth - 1)
-  {
-    out.push_back(cell);
-    return;
-  }
-
   uint64_t const cellArea = std::pow(uint64_t(1 << (cellDepth - 1 - cell.Level())), 2);
   CellObjectIntersection const intersection = intersect(cell);
 
   if (intersection == CELL_OBJECT_NO_INTERSECTION)
     return;
   if (intersection == CELL_INSIDE_OBJECT || cellPenaltyArea >= cellArea)
+  {
+    out.push_back(cell);
+    return;
+  }
+
+  if (cell.Level() == cellDepth - 1)
   {
     out.push_back(cell);
     return;

--- a/indexer/cell_id.hpp
+++ b/indexer/cell_id.hpp
@@ -11,11 +11,11 @@
 
 using RectId = m2::CellId<19>;
 
-// 24 is enough to have cell size < 2.5m * 2.5m for world.
-constexpr int kGeoObjectsDepthLevels = 24;
+// 23 is enough to have cell size < 10m * 10m for world.
+constexpr int kGeoObjectsDepthLevels = 23;
 
-// Cell size < 40m * 40m for world is good for regions.
-constexpr int kRegionsDepthLevels = 20;
+// Cell size < 150m * 150m for world is good for regions.
+constexpr int kRegionsDepthLevels = 19;
 
 template <typename Bounds, typename CellId>
 class CellIdConverter


### PR DESCRIPTION
Фикс покрытия целами: объект покрывался, максимум до предпоследнего уровня.
Размер regions.locidx уменьшился на 5%.

Требуется обновления rounover и nominator.