### PR TITLE
[generator:region] Speedup locality index building: parallel region object covering

### DIFF
--- a/base/thread_pool_computational.hpp
+++ b/base/thread_pool_computational.hpp
@@ -107,7 +107,8 @@ public:
   template <typename F, typename... Args>
   void PerformParallelWorks(F && func, size_t workersCountHint)
   {
-    size_t const workersCount = std::min(std::max(size_t{1}, workersCountHint), Size());
+    size_t const workersCount = std::min(std::max(1u, static_cast<unsigned int>(workersCountHint)),
+                                         Size());
 
     std::vector<std::future<void>> workers{};
     workers.reserve(workersCount);
@@ -143,7 +144,7 @@ public:
     m_joiner.Join();
   }
 
-  size_t Size() const noexcept { return m_threads.size(); }
+  unsigned int Size() const noexcept { return static_cast<unsigned int>(m_threads.size()); }
 
 private:
   void Worker()

--- a/generator/covering_index_generator.cpp
+++ b/generator/covering_index_generator.cpp
@@ -233,9 +233,9 @@ bool GenerateRegionsIndex(std::string const & outPath, std::string const & featu
                           unsigned int threadsCount)
 {
   base::thread_pool::computational::ThreadPool threadPool{threadsCount};
-  auto const featuresFilter = [](FeatureBuilder & fb) { return fb.IsArea(); };
-  indexer::RegionsIndexBuilder indexBuilder;
+  indexer::RegionsIndexBuilder indexBuilder{threadPool};
 
+  auto const featuresFilter = [](FeatureBuilder & fb) { return fb.IsArea(); };
   covering::ObjectsCovering objectsCovering;
   CoverFeatures(featuresFile, featuresFilter, indexBuilder, threadsCount,
                 1 /* chunkFeaturesCount */, threadPool, objectsCovering);
@@ -255,7 +255,7 @@ bool GenerateGeoObjectsIndex(
 {
   base::thread_pool::computational::ThreadPool threadPool{threadsCount};
   covering::ObjectsCovering objectsCovering;
-  indexer::GeoObjectsIndexBuilder indexBuilder;
+  indexer::GeoObjectsIndexBuilder indexBuilder{threadPool};
 
   set<uint64_t> nodeIds;
   if (nodesFile && !ParseNodes(*nodesFile, nodeIds))

--- a/generator/regions/regions_builder.cpp
+++ b/generator/regions/regions_builder.cpp
@@ -174,7 +174,7 @@ std::list<RegionsBuilder::ParentChildPairs> RegionsBuilder::FindParentChildPairs
 {
   constexpr auto nodesCountPerTask = 1000;
   auto const tasksCount = std::min(std::max(size_t{1}, nodes.size() / nodesCountPerTask),
-                                   m_taskProcessingThreadPool.Size());
+                                   size_t{m_taskProcessingThreadPool.Size()});
 
   CHECK(!nodes.empty(), ());
   std::atomic_size_t unprocessedIndex{1};

--- a/indexer/feature_covering.hpp
+++ b/indexer/feature_covering.hpp
@@ -11,6 +11,7 @@
 #include "geometry/rect2d.hpp"
 
 #include "base/logging.hpp"
+#include "base/thread_pool_computational.hpp"
 
 #include <cstdint>
 #include <set>
@@ -32,7 +33,8 @@ typedef std::vector<Interval> Intervals;
 // Cover feature with RectIds and return their integer representations.
 std::vector<int64_t> CoverFeature(FeatureType & feature, int cellDepth, uint64_t cellPenaltyArea);
 
-std::vector<int64_t> CoverRegion(indexer::CoveredObject const & o, int cellDepth);
+std::vector<int64_t> CoverRegion(indexer::CoveredObject const & o, int cellDepth,
+                                 base::thread_pool::computational::ThreadPool & threadPool);
 std::vector<int64_t> CoverGeoObject(indexer::CoveredObject const & o, int cellDepth);
 
 // Given a vector of intervals [a, b), sort them and merge overlapping intervals.

--- a/indexer/indexer_tests/locality_index_test.cpp
+++ b/indexer/indexer_tests/locality_index_test.cpp
@@ -26,7 +26,8 @@ namespace
 template <class ObjectsVector, class Writer>
 void BuildGeoObjectsIndex(ObjectsVector const & objects, Writer && writer)
 {
-  indexer::GeoObjectsIndexBuilder indexBuilder;
+  base::thread_pool::computational::ThreadPool threadPool{1};
+  indexer::GeoObjectsIndexBuilder indexBuilder{threadPool};
 
   covering::ObjectsCovering objectsCovering;
   for (auto const & object : objects)


### PR DESCRIPTION
Ускорение генерации regions_index.locidx.
Некоторое регионы требую большого объёма вычислений для покрытия геометрии cell-ами. Такие объекты обрабатываются параллельно.

Сам по себе PR ускоряет генерацию regions_index.locidx менее чем в 2 раза (17m:32s vs 30m:30s), но совместно с PR #79 генерация сокращается в 4 раза (7m:15s vs 30m:30s)