### PR TITLE
[generator:regions] Parallel build regions tree

### DIFF
--- a/base/thread_pool_computational.hpp
+++ b/base/thread_pool_computational.hpp
@@ -125,6 +125,8 @@ public:
     m_joiner.Join();
   }
 
+  size_t Size() const noexcept { return m_threads.size(); }
+
 private:
   void Worker()
   {

--- a/generator/generator_tests/regions_tests.cpp
+++ b/generator/generator_tests/regions_tests.cpp
@@ -123,7 +123,8 @@ std::vector<std::string> GenerateTestRegions(std::vector<OsmElementData> const &
   RegionInfo collector(filename);
   BuildTestData(testData, regions, placePointsMap, collector);
 
-  RegionsBuilder builder(std::move(regions), std::move(placePointsMap));
+  base::thread_pool::computational::ThreadPool threadsPool{1};
+  RegionsBuilder builder(std::move(regions), std::move(placePointsMap), threadsPool);
   std::vector<std::string> kvRegions;
   builder.ForEachCountry([&](std::string const & /*name*/, Node::PtrList const & outers) {
     for (auto const & tree : outers)
@@ -292,7 +293,8 @@ UNIT_TEST(RegionsBuilderTest_GetCountryNames)
   auto const filename = MakeCollectorData();
   SCOPE_GUARD(removeCollectorFile, std::bind(Platform::RemoveFileIfExists, std::cref(filename)));
   RegionInfo collector(filename);
-  RegionsBuilder builder(MakeTestDataSet1(collector), {} /* placePointsMap */);
+  base::thread_pool::computational::ThreadPool threadsPool{1};
+  RegionsBuilder builder(MakeTestDataSet1(collector), {} /* placePointsMap */, threadsPool);
   auto const & countryNames = builder.GetCountryInternationalNames();
   TEST_EQUAL(countryNames.size(), 2, ());
   TEST(std::count(std::begin(countryNames), std::end(countryNames), "Country_1"), ());
@@ -304,7 +306,8 @@ UNIT_TEST(RegionsBuilderTest_GetCountries)
   auto const filename = MakeCollectorData();
   SCOPE_GUARD(removeCollectorFile, std::bind(Platform::RemoveFileIfExists, std::cref(filename)));
   RegionInfo collector(filename);
-  RegionsBuilder builder(MakeTestDataSet1(collector), {} /* placePointsMap */);
+  base::thread_pool::computational::ThreadPool threadsPool{1};
+  RegionsBuilder builder(MakeTestDataSet1(collector), {} /* placePointsMap */, threadsPool);
   auto const & countries = builder.GetCountriesOuters();
   TEST_EQUAL(countries.size(), 3, ());
   size_t countries1 = std::count_if(std::begin(countries), std::end(countries),
@@ -322,7 +325,8 @@ UNIT_TEST(RegionsBuilderTest_GetCountryTrees)
   SCOPE_GUARD(removeCollectorFile, std::bind(Platform::RemoveFileIfExists, std::cref(filename)));
   RegionInfo collector(filename);
   std::vector<std::string> bankOfNames;
-  RegionsBuilder builder(MakeTestDataSet1(collector), {} /* placePointsMap */);
+  base::thread_pool::computational::ThreadPool threadsPool{1};
+  RegionsBuilder builder(MakeTestDataSet1(collector), {} /* placePointsMap */, threadsPool);
   builder.ForEachCountry([&](std::string const & /*name*/, Node::PtrList const & outers) {
     for (auto const & tree : outers)
     {

--- a/generator/regions/regions.cpp
+++ b/generator/regions/regions.cpp
@@ -43,6 +43,8 @@ public:
                    bool verbose, unsigned int threadsCount)
     : m_pathRegionsTmpMwm{pathRegionsTmpMwm}
     , m_pathOutRegionsKv{pathOutRegionsKv}
+    , m_threadsCount{threadsCount}
+    , m_taskProcessingThreadPool{threadsCount}
     , m_verbose{verbose}
     , m_regionsInfoCollector{pathInRegionsCollector}
     , m_regionsKv{pathOutRegionsKv, std::ofstream::out}
@@ -54,7 +56,8 @@ public:
     PlacePointsMap placePointsMap;
     std::tie(regions, placePointsMap) =
         ReadDatasetFromTmpMwm(m_pathRegionsTmpMwm, m_regionsInfoCollector);
-    RegionsBuilder builder{std::move(regions), std::move(placePointsMap), threadsCount};
+    RegionsBuilder builder{
+        std::move(regions), std::move(placePointsMap), m_taskProcessingThreadPool};
 
     GenerateRegions(builder);
     LOG(LINFO, ("Finish generating regions.", timer.ElapsedSeconds(), "seconds."));
@@ -338,6 +341,9 @@ private:
 
   std::string m_pathRegionsTmpMwm;
   std::string m_pathOutRegionsKv;
+
+  unsigned int m_threadsCount{1};
+  base::thread_pool::computational::ThreadPool mutable m_taskProcessingThreadPool;
 
   bool m_verbose{false};
 


### PR DESCRIPTION
Ускорение генерации kv регионов: параллельный поиск вхождений одного региона в другой (определение подчинений).

Генерация ускорилась на ~30% (на 10 минут):
до
```
real    37m21.815s
user    226m32.444s
sys     15m47.565s
```
после
```
real    27m33.527s
user    335m38.346s
sys     37m29.859s
```